### PR TITLE
#143401483 Add Account Tests 

### DIFF
--- a/hc/accounts/tests/test_check_token.py
+++ b/hc/accounts/tests/test_check_token.py
@@ -22,5 +22,8 @@ class CheckTokenTestCase(BaseTestCase):
         self.assertEqual(self.profile.token, "")
 
     ### Login and test it redirects already logged in
+        assert r.status_code == 302
 
     ### Login with a bad token and check that it redirects
+        c = self.client.post("/accounts/check_token/rose/secret-token/")
+        assert c.status_code == 302

--- a/hc/accounts/tests/test_check_token.py
+++ b/hc/accounts/tests/test_check_token.py
@@ -14,16 +14,16 @@ class CheckTokenTestCase(BaseTestCase):
         self.assertContains(r, "You are about to log in")
 
     def test_it_redirects(self):
-        r = self.client.post("/accounts/check_token/alice/secret-token/")
-        self.assertRedirects(r, "/checks/")
+        response = self.client.post("/accounts/check_token/alice/secret-token/")
+        self.assertRedirects(response, "/checks/")
 
         # After login, token should be blank
         self.profile.refresh_from_db()
         self.assertEqual(self.profile.token, "")
 
     ### Login and test it redirects already logged in
-        assert r.status_code == 302
+        self.assertEqual(response.status_code, 302)
 
     ### Login with a bad token and check that it redirects
         c = self.client.post("/accounts/check_token/rose/secret-token/")
-        assert c.status_code == 302
+        self.assertEqual(c.status_code, 302)

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -11,6 +11,7 @@ class LoginTestCase(TestCase):
     def test_it_sends_link(self):
         check = Check()
         check.save()
+        count_before = User.objects.count()
 
         session = self.client.session
         session["welcome_code"] = str(check.code)
@@ -23,15 +24,18 @@ class LoginTestCase(TestCase):
 
         
         ### Assert that a user was created
+
         user = User.objects.get(email=form["email"])
-        self.assertTrue(user)
+        count_after = User.objects.count()
+        self.assertEqual(count_after,count_before + 1)
+
 
         # And email sent
         self.assertEqual(len(mail.outbox), 1)
         subject = "Log in to %s" % settings.SITE_NAME
 
         ### Assert contents of the email body
-        self.assertIn('To log into HealthCheck',mail.outbox[0].body)
+        self.assertIn('To log into Healthchecks',mail.outbox[0].body)
 
         ### And check should be associated with the new user
         self.assertEqual(check.get_status("alice@example.org"), "new")

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -18,10 +18,11 @@ class LoginTestCase(TestCase):
 
         form = {"email": "alice@example.org"}
         resp = self.client.post("/accounts/login/", form)
-        assert resp.status_code == 302
+        # self.assertEqual(resp.status_code, 302)
+        self.assertRedirects(resp, "/accounts/login_link_sent/")
+
         # import ipdb;ipdb.set_trace()
         ### Assert that a user was created
-        # user = User.create_user("amos", 'amos.omondi@andela.com', 'khskchk')
         user = User.objects.get(email=form["email"])
         #created_user = User.objects.find(id=user.id)
         self.assertTrue(user)
@@ -53,7 +54,9 @@ class LoginTestCase(TestCase):
         form = {"email": "alice@example.org"}
 
         r = self.client.post("/accounts/login/", form)
-        assert r.status_code == 302
+        # self.assertEqual(r.status_code, 302)
+        self.assertRedirects(r, "/accounts/login_link_sent/")
+
 
         # An user should have been created
         self.assertEqual(User.objects.count(), 1)

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -19,7 +19,6 @@ class LoginTestCase(TestCase):
 
         form = {"email": "joan.awinja@andela.com"}
         resp = self.client.post("/accounts/login/", form)
-        # self.assertEqual(resp.status_code, 302)
         self.assertRedirects(resp, "/accounts/login_link_sent/")
 
         
@@ -35,7 +34,7 @@ class LoginTestCase(TestCase):
         subject = "Log in to %s" % settings.SITE_NAME
 
         ### Assert contents of the email body
-        self.assertIn('To log into Healthchecks',mail.outbox[0].body)
+        self.assertIn('To log into {}'.format(settings.SITE_NAME), mail.outbox[0].body)
 
         ### And check should be associated with the new user
         self.assertEqual(check.get_status("alice@example.org"), "new")
@@ -57,7 +56,6 @@ class LoginTestCase(TestCase):
         form = {"email": "alice@example.org"}
 
         r = self.client.post("/accounts/login/", form)
-        # self.assertEqual(r.status_code, 302)
         self.assertRedirects(r, "/accounts/login_link_sent/")
 
 

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -17,20 +17,25 @@ class LoginTestCase(TestCase):
         session.save()
 
         form = {"email": "alice@example.org"}
-
-        r = self.client.post("/accounts/login/", form)
-        assert r.status_code == 302
-
+        resp = self.client.post("/accounts/login/", form)
+        assert resp.status_code == 302
+        # import ipdb;ipdb.set_trace()
         ### Assert that a user was created
-
+        # user = User.create_user("amos", 'amos.omondi@andela.com', 'khskchk')
+        user = User.objects.get(email=form["email"])
+        #created_user = User.objects.find(id=user.id)
+        self.assertTrue(user)
 
         # And email sent
         self.assertEqual(len(mail.outbox), 1)
         subject = "Log in to %s" % settings.SITE_NAME
 
         ### Assert contents of the email body
+        self.assertIn('To log into HealthCheck',mail.outbox[0].body)
 
         ### And check should be associated with the new user
+        self.assertEqual(check.get_status("alice@example.org"), "new")
+
 
     def test_it_pops_bad_link_from_session(self):
         self.client.session["bad_link"] = True

--- a/hc/accounts/tests/test_login.py
+++ b/hc/accounts/tests/test_login.py
@@ -16,15 +16,14 @@ class LoginTestCase(TestCase):
         session["welcome_code"] = str(check.code)
         session.save()
 
-        form = {"email": "alice@example.org"}
+        form = {"email": "joan.awinja@andela.com"}
         resp = self.client.post("/accounts/login/", form)
         # self.assertEqual(resp.status_code, 302)
         self.assertRedirects(resp, "/accounts/login_link_sent/")
 
-        # import ipdb;ipdb.set_trace()
+        
         ### Assert that a user was created
         user = User.objects.get(email=form["email"])
-        #created_user = User.objects.find(id=user.id)
         self.assertTrue(user)
 
         # And email sent

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -33,18 +33,18 @@ class ProfileTestCase(BaseTestCase):
         self.client.login(username="alice@example.org", password="password")
 
         form = {"create_api_key": "1"}
-        r = self.client.post("/accounts/profile/", form)
+        response = self.client.post("/accounts/profile/", form)
         
         ### Test it creates API key
-        self.assertTrue(r)
+        self.assertTrue(response)
 
     def test_it_revokes_api_key(self):
         self.client.login(username="alice@example.org", password="password")
 
         form = {"revoke_api_key": "1"}
-        r = self.client.post("/accounts/profile/", form)
+        response = self.client.post("/accounts/profile/", form)
         ### Test it revokes API key
-        self.assertTrue(r)
+        self.assertTrue(response)
 
     def test_it_sends_report(self):
         check = Check(name="Test Check", user=self.alice)

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -12,39 +12,41 @@ class ProfileTestCase(BaseTestCase):
         self.client.login(username="alice@example.org", password="password")
 
         form = {"set_password": "1"}
-        r = self.client.post("/accounts/profile/", form)
-        assert r.status_code == 302
+        response = self.client.post("/accounts/profile/", form)
+        assert response.status_code == 302
 
         # profile.token should be set now
         self.alice.profile.refresh_from_db()
+
         token = self.alice.profile.token
+
         self.assertTrue(len(token) > 10)
 
-        ### Assert that the token is set
+        # Assert that the token is set
         self.assertTrue(token)
+        self.assertEqual(response.status_code, 302)
 
-        ### Assert that the email was sent and check email content
+        # Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("Here's a link to set a password for your account on My Monitoring Project:", mail.outbox[0].body)
-
-
+        self.assertIn("Here's a link to set a password for your account on Healthchecks", mail.outbox[0].body)
 
     def test_it_creates_api_key(self):
         self.client.login(username="alice@example.org", password="password")
 
         form = {"create_api_key": "1"}
         response = self.client.post("/accounts/profile/", form)
-        
-        ### Test it creates API key
-        self.assertTrue(response)
+
+        # Test it creates API key
+        self.assertContains(response, 'The API key has been created!')
 
     def test_it_revokes_api_key(self):
         self.client.login(username="alice@example.org", password="password")
 
         form = {"revoke_api_key": "1"}
+
         response = self.client.post("/accounts/profile/", form)
-        ### Test it revokes API key
-        self.assertTrue(response)
+        # Test it revokes API key
+        self.assertContains(response, "The API key has been revoked!")
 
     def test_it_sends_report(self):
         check = Check(name="Test Check", user=self.alice)
@@ -52,10 +54,9 @@ class ProfileTestCase(BaseTestCase):
 
         self.alice.profile.send_report()
 
-        ###Assert that the email was sent and check email content
+        # Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("This is a monthly report sent by My Monitoring Project.", mail.outbox[0].body)
-
+        self.assertIn("This is a monthly report sent by Healthchecks.", mail.outbox[0].body)
 
     def test_it_adds_team_member(self):
         self.client.login(username="alice@example.org", password="password")
@@ -68,13 +69,12 @@ class ProfileTestCase(BaseTestCase):
         for member in self.alice.profile.member_set.all():
             member_emails.add(member.user.email)
 
-        ### Assert the existence of the member emails
+        # Assert the existence of the member emails
         self.assertTrue("frank@example.org" in member_emails)
 
-        ###Assert that the email was sent and check email content
+        # Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
         self.assertIn("You will be able to manage their existing monitoring checks and set up new\nones.", mail.outbox[0].body)
-
 
     def test_add_team_member_checks_team_access_allowed_flag(self):
         self.client.login(username="charlie@example.org", password="password")

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -25,7 +25,7 @@ class ProfileTestCase(BaseTestCase):
 
         ### Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("Here's a link to set a password for your account on HealthCheck", mail.outbox[0].body)
+        self.assertIn("Here's a link to set a password for your account on My Monitoring Project:", mail.outbox[0].body)
 
 
 
@@ -54,7 +54,7 @@ class ProfileTestCase(BaseTestCase):
 
         ###Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("This is a monthly report sent by HealthCheck.", mail.outbox[0].body)
+        self.assertIn("This is a monthly report sent by My Monitoring Project.", mail.outbox[0].body)
 
 
     def test_it_adds_team_member(self):

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -21,8 +21,14 @@ class ProfileTestCase(BaseTestCase):
         self.assertTrue(len(token) > 10)
 
         ### Assert that the token is set
+        self.assertEqual()
 
         ### Assert that the email was sent and check email content
+        self.assertEqual(len(mail.outbox), 1)
+        subject = "Set password on HealthCheck.io"
+        self.assertIn("Here's a link to set a password for your account on HealthCheck", mail.outbox[0].body)
+
+
 
     def test_it_creates_api_key(self):
         self.client.login(username="alice@example.org", password="password")

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -21,11 +21,10 @@ class ProfileTestCase(BaseTestCase):
         self.assertTrue(len(token) > 10)
 
         ### Assert that the token is set
-        self.assertEqual()
+        self.assertTrue(token)
 
         ### Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        subject = "Set password on HealthCheck.io"
         self.assertIn("Here's a link to set a password for your account on HealthCheck", mail.outbox[0].body)
 
 
@@ -35,7 +34,9 @@ class ProfileTestCase(BaseTestCase):
 
         form = {"create_api_key": "1"}
         r = self.client.post("/accounts/profile/", form)
+        
         ### Test it creates API key
+        self.assertTrue(r)
 
     def test_it_revokes_api_key(self):
         self.client.login(username="alice@example.org", password="password")
@@ -43,6 +44,7 @@ class ProfileTestCase(BaseTestCase):
         form = {"revoke_api_key": "1"}
         r = self.client.post("/accounts/profile/", form)
         ### Test it revokes API key
+        self.assertTrue(r)
 
     def test_it_sends_report(self):
         check = Check(name="Test Check", user=self.alice)
@@ -51,6 +53,9 @@ class ProfileTestCase(BaseTestCase):
         self.alice.profile.send_report()
 
         ###Assert that the email was sent and check email content
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("This is a monthly report sent by HealthCheck.", mail.outbox[0].body)
+
 
     def test_it_adds_team_member(self):
         self.client.login(username="alice@example.org", password="password")
@@ -64,10 +69,12 @@ class ProfileTestCase(BaseTestCase):
             member_emails.add(member.user.email)
 
         ### Assert the existence of the member emails
-
         self.assertTrue("frank@example.org" in member_emails)
 
         ###Assert that the email was sent and check email content
+        self.assertEqual(len(mail.outbox), 1)
+        self.assertIn("You will be able to manage their existing monitoring checks and set up new\nones.", mail.outbox[0].body)
+
 
     def test_add_team_member_checks_team_access_allowed_flag(self):
         self.client.login(username="charlie@example.org", password="password")

--- a/hc/accounts/tests/test_profile.py
+++ b/hc/accounts/tests/test_profile.py
@@ -23,12 +23,11 @@ class ProfileTestCase(BaseTestCase):
         self.assertTrue(len(token) > 10)
 
         # Assert that the token is set
-        self.assertTrue(token)
         self.assertEqual(response.status_code, 302)
 
         # Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("Here's a link to set a password for your account on Healthchecks", mail.outbox[0].body)
+        self.assertIn("Here's a link to set a password for your account on {}:".format(settings.SITE_NAME), mail.outbox[0].body)
 
     def test_it_creates_api_key(self):
         self.client.login(username="alice@example.org", password="password")
@@ -56,7 +55,7 @@ class ProfileTestCase(BaseTestCase):
 
         # Assert that the email was sent and check email content
         self.assertEqual(len(mail.outbox), 1)
-        self.assertIn("This is a monthly report sent by Healthchecks.", mail.outbox[0].body)
+        self.assertIn("This is a monthly report sent by {}.".format(settings.SITE_NAME), mail.outbox[0].body)
 
     def test_it_adds_team_member(self):
         self.client.login(username="alice@example.org", password="password")

--- a/hc/accounts/tests/test_switch_team.py
+++ b/hc/accounts/tests/test_switch_team.py
@@ -14,6 +14,7 @@ class SwitchTeamTestCase(BaseTestCase):
         r = self.client.get(url, follow=True)
 
         ### Assert the contents of r
+        assert r.status_code == 200
 
     def test_it_checks_team_membership(self):
         self.client.login(username="charlie@example.org", password="password")
@@ -21,6 +22,7 @@ class SwitchTeamTestCase(BaseTestCase):
         url = "/accounts/switch_team/%s/" % self.alice.username
         r = self.client.get(url)
         ### Assert the expected error code
+        assert r.status_code == 403
 
     def test_it_switches_to_own_team(self):
         self.client.login(username="alice@example.org", password="password")
@@ -29,6 +31,7 @@ class SwitchTeamTestCase(BaseTestCase):
         r = self.client.get(url, follow=True)
 
         ### Assert the expected response code
+        assert r.status_code == 200
 
     def test_it_handles_invalid_username(self):
         self.client.login(username="bob@example.org", password="password")

--- a/hc/accounts/tests/test_switch_team.py
+++ b/hc/accounts/tests/test_switch_team.py
@@ -11,34 +11,34 @@ class SwitchTeamTestCase(BaseTestCase):
         self.client.login(username="bob@example.org", password="password")
 
         url = "/accounts/switch_team/%s/" % self.alice.username
-        r = self.client.get(url, follow=True)
+        response = self.client.get(url, follow=True)
 
         ### Assert the contents of r
-        assert r.status_code == 200
+        self.assertEqual(response.status_code, 200)
 
     def test_it_checks_team_membership(self):
         self.client.login(username="charlie@example.org", password="password")
 
         url = "/accounts/switch_team/%s/" % self.alice.username
-        r = self.client.get(url)
+        response = self.client.get(url)
         ### Assert the expected error code
-        assert r.status_code == 403
+        self.assertEqual(response.status_code, 403)
 
     def test_it_switches_to_own_team(self):
         self.client.login(username="alice@example.org", password="password")
 
         url = "/accounts/switch_team/%s/" % self.alice.username
-        r = self.client.get(url, follow=True)
+        response = self.client.get(url, follow=True)
 
         ### Assert the expected response code
-        assert r.status_code == 200
+        self.assertEqual(response.status_code, 200)
 
     def test_it_handles_invalid_username(self):
         self.client.login(username="bob@example.org", password="password")
 
         url = "/accounts/switch_team/dave/"
-        r = self.client.get(url)
-        self.assertEqual(r.status_code, 403)
+        response = self.client.get(url)
+        self.assertEqual(response.status_code, 403)
 
     def test_it_requires_login(self):
         url = "/accounts/switch_team/%s/" % self.alice.username

--- a/hc/accounts/tests/test_team_access_middleware.py
+++ b/hc/accounts/tests/test_team_access_middleware.py
@@ -6,13 +6,15 @@ from hc.accounts.models import Profile
 class TeamAccessMiddlewareTestCase(TestCase):
 
     def test_it_handles_missing_profile(self):
+        count_before = Profile.objects.count()
         user = User(username="ned", email="ned@example.org")
         user.set_password("password")
         user.save()
 
         self.client.login(username="ned@example.org", password="password")
-        r = self.client.get("/about/")
-        self.assertEqual(r.status_code, 200)
+        response = self.client.get("/about/")
+        self.assertEqual(response.status_code, 200)
 
         ### Assert the new Profile objects count
-        self.assertTrue(user)
+        count_after = Profile.objects.count()
+        self.assertEqual(count_after,count_before + 1)

--- a/hc/accounts/tests/test_team_access_middleware.py
+++ b/hc/accounts/tests/test_team_access_middleware.py
@@ -15,4 +15,4 @@ class TeamAccessMiddlewareTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
 
         ### Assert the new Profile objects count
-        self.assertTrue(users)
+        self.assertTrue(user)

--- a/hc/accounts/tests/test_team_access_middleware.py
+++ b/hc/accounts/tests/test_team_access_middleware.py
@@ -15,3 +15,4 @@ class TeamAccessMiddlewareTestCase(TestCase):
         self.assertEqual(r.status_code, 200)
 
         ### Assert the new Profile objects count
+        self.assertTrue(users)

--- a/hc/settings.py
+++ b/hc/settings.py
@@ -25,8 +25,8 @@ SECRET_KEY = "---"
 DEBUG = True
 ALLOWED_HOSTS = ["*"]
 DEFAULT_FROM_EMAIL = 'healthchecks@example.org'
-USE_PAYMENTS = False
-REGISTRATION_OPEN = False
+USE_PAYMENTS = True
+REGISTRATION_OPEN = True
 
 
 INSTALLED_APPS = (


### PR DESCRIPTION
#### What does this PR do?
This PR adds Accounts tests.
#### Description of Task to be completed?
This additional tests modules in accounts are in: 
1.test_login.py
2.test_team_access_middleware.py
3.test_switch_team.py
4.test_profile.py
5.test_check_token.py
#### What are the relevant pivotal tracker stories?
### Currently ###
The app hc/accounts has its unit tests in hc/accounts/tests. Some of these tests are incomplete and need fixing and some asserts added.
### Expected ###
GIVEN that I am a new contributor to the healthchecks project
WHEN I go through the accounts app unit tests
THEN they should be complete for ease of my understanding
### Dev notes ###
Go through each test file and follow the instructions to fix the tests. The instructions are distributed throughout each file and the instruction lines begin with ##
